### PR TITLE
Expose tcp_sock.snd_cwnd through getsockopt()

### DIFF
--- a/net/ipv4/tcp.c
+++ b/net/ipv4/tcp.c
@@ -2919,6 +2919,10 @@ static int do_tcp_getsockopt(struct sock *sk, int level,
 		if (copy_to_user(optval, &fst, len))
 			return -EFAULT;
 		return 0;
+	case TCP_CWND:
+	case TCP_CWND2:
+		val = tp->snd_cwnd;
+		break;
 	}
 	default:
 		return -ENOPROTOOPT;


### PR DESCRIPTION
Needed for the better long-term fix for https://github.com/fastly/Varnish/pull/807 .
